### PR TITLE
Adds Stock Update Product Quantity endpoint call

### DIFF
--- a/PortaCapena.OdooJsonRpcClient/Consts/OdooOperation.cs
+++ b/PortaCapena.OdooJsonRpcClient/Consts/OdooOperation.cs
@@ -12,6 +12,8 @@
         public const string Update = "write";
         public const string Delete = "unlink";
 
+        public const string ChangeProductQty = "change_product_qty";
+
         public const string NameGet = "name_get";
         public const string SearchCount = "search_count";
         public const string GetMetadata = "get_metadata";

--- a/PortaCapena.OdooJsonRpcClient/OdooClient.cs
+++ b/PortaCapena.OdooJsonRpcClient/OdooClient.cs
@@ -248,6 +248,20 @@ namespace PortaCapena.OdooJsonRpcClient
 
         #endregion
 
+        #region Change product quantity
+        public async Task<OdooResult<Dictionary<string, object>>> ChangeProductQuantity(long changeProductQuantityId, OdooContext context = null, CancellationToken cancellationToken = default)
+        {
+            return await ExecuteWitrAccesDenideRetryAsync(userUid => ChangeProductQuantity(Config, userUid, changeProductQuantityId, SelectContext(context, Config.Context), cancellationToken));
+        }
+
+        public static async Task<OdooResult<Dictionary<string, object>>> ChangeProductQuantity(OdooConfig config, int userUid, long changeProductQuantityId, OdooContext context, CancellationToken cancellationToken = default)
+        {
+            var request = OdooRequestModel.ChangeProductQuantity(config, userUid, new long[] { changeProductQuantityId }, context);
+            return await CallAndDeserializeAsync<Dictionary<string, object>>(request, cancellationToken);
+        }
+
+        #endregion
+
         #region Login
 
         public async Task<OdooResult<int>> GetCurrentUserUidOrLoginAsync(CancellationToken cancellationToken = default)

--- a/PortaCapena.OdooJsonRpcClient/OdooRepository.cs
+++ b/PortaCapena.OdooJsonRpcClient/OdooRepository.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
 using PortaCapena.OdooJsonRpcClient.Extensions;
 using PortaCapena.OdooJsonRpcClient.Models;
 using PortaCapena.OdooJsonRpcClient.Request;
@@ -58,6 +59,10 @@ namespace PortaCapena.OdooJsonRpcClient
         public async Task<OdooResult<bool>> DeleteRangeAsync(T[] models, OdooContext context = null)
         {
             return await OdooClient.DeleteRangeAsync(models as IOdooModel[], context);
+        }
+        public async Task<OdooResult<Dictionary<string, object>>> UpdateProductQuantity(long id, OdooContext context = null)
+        {
+            return await OdooClient.ChangeProductQuantity(id, context);
         }
     }
 }

--- a/PortaCapena.OdooJsonRpcClient/Request/OdooRequestModel.cs
+++ b/PortaCapena.OdooJsonRpcClient/Request/OdooRequestModel.cs
@@ -89,6 +89,11 @@ namespace PortaCapena.OdooJsonRpcClient.Request
             var param = new OdooRequestParams(config.ApiUrlJson, "object", "execute_kw", config.DbName, uid, config.Password, tableName, OdooOperation.Delete, ids, MapQuery(context));
             return new OdooRequestModel(param);
         }
+        public static OdooRequestModel ChangeProductQuantity(OdooConfig config, int uid, long[] ids, OdooContext context = null)
+        {
+            var param = new OdooRequestParams(config.ApiUrlJson, "object", "execute_kw", config.DbName, uid, config.Password, "stock.change.product.qty", OdooOperation.ChangeProductQty, ids, MapQuery(context));
+            return new OdooRequestModel(param);
+        }
 
         public static OdooRequestModel Metadata(OdooConfig config, int uid, string tableName, long[] ids, OdooContext context = null)
         {


### PR DESCRIPTION
Adds the ability to call the method `change_product_qty` to dispatch the event after creating an entry in the `stock.change.product.qty` table.

Without this call, updating a product stock quantity would need to manually update/insert in a least 4 different tables, all not synchronized.

This call does what clicking on the `apply` button under the hood.

![image](https://github.com/Intechnity-com/OdooJsonRpcClient/assets/9405810/991ad7a4-41b4-4b7b-b2b0-719b65bbc36f)
